### PR TITLE
Renaming methods to avoid collisions

### DIFF
--- a/ds18b20.c
+++ b/ds18b20.c
@@ -21,7 +21,7 @@
 int DS_GPIO;
 int init=0;
 /// Sends one bit to bus
-void send(char bit){
+void ds18b20_send(char bit){
   gpio_set_direction(DS_GPIO, GPIO_MODE_OUTPUT);
   gpio_set_level(DS_GPIO,0);
   ets_delay_us(5);
@@ -30,7 +30,7 @@ void send(char bit){
   gpio_set_level(DS_GPIO,1);
 }
 // Reads one bit from bus
-unsigned char read(void){
+unsigned char ds18b20_read(void){
   unsigned char PRESENCE=0;
   gpio_set_direction(DS_GPIO, GPIO_MODE_OUTPUT);
   gpio_set_level(DS_GPIO,0);
@@ -42,29 +42,29 @@ unsigned char read(void){
   return(PRESENCE);
 }
 // Sends one byte to bus
-void send_byte(char data){
+void ds18b20_send_byte(char data){
   unsigned char i;
   unsigned char x;
   for(i=0;i<8;i++){
     x = data>>i;
     x &= 0x01;
-    send(x);
+    ds18b20_send(x);
   }
   ets_delay_us(100);
 }
 // Reads one byte from bus
-unsigned char read_byte(void){
+unsigned char ds18b20_read_byte(void){
   unsigned char i;
   unsigned char data = 0;
   for (i=0;i<8;i++)
   {
-    if(read()) data|=0x01<<i;
+    if(ds18b20_read()) data|=0x01<<i;
     ets_delay_us(15);
   }
   return(data);
 }
 // Sends reset pulse
-unsigned char RST_PULSE(void){
+unsigned char ds18b20_RST_PULSE(void){
   unsigned char PRESENCE;
   gpio_set_direction(DS_GPIO, GPIO_MODE_OUTPUT);
   gpio_set_level(DS_GPIO,0);
@@ -78,22 +78,22 @@ unsigned char RST_PULSE(void){
   return PRESENCE;
 }
 // Returns temperature from sensor
-float DS_get_temp(void) {
+float ds18b20_get_temp(void) {
   if(init==1){
     unsigned char check;
     char temp1=0, temp2=0;
-      check=RST_PULSE();
+      check=ds18b20_RST_PULSE();
       if(check==1)
       {
-        send_byte(0xCC);
-        send_byte(0x44);
+        ds18b20_send_byte(0xCC);
+        ds18b20_send_byte(0x44);
         vTaskDelay(750 / portTICK_RATE_MS);
-        check=RST_PULSE();
-        send_byte(0xCC);
-        send_byte(0xBE);
-        temp1=read_byte();
-        temp2=read_byte();
-        check=RST_PULSE();
+        check=ds18b20_RST_PULSE();
+        ds18b20_send_byte(0xCC);
+        ds18b20_send_byte(0xBE);
+        temp1=ds18b20_read_byte();
+        temp2=ds18b20_read_byte();
+        check=ds18b20_RST_PULSE();
         float temp=0;
         temp=(float)(temp1+(temp2*256))/16;
         return temp;
@@ -103,7 +103,7 @@ float DS_get_temp(void) {
   }
   else{return 0;}
 }
-void DS_init(int GPIO){
+void ds18b20_init(int GPIO){
   DS_GPIO = GPIO;
   gpio_pad_select_gpio(DS_GPIO);
   init=1;

--- a/ds18b20.h
+++ b/ds18b20.h
@@ -15,12 +15,12 @@
 #ifndef DS18B20_H_  
 #define DS18B20_H_
 
-void send(char bit);
-unsigned char read(void);
-void send_byte(char data);
-unsigned char read_byte(void);
-unsigned char RST_PULSE(void);
-float DS_get_temp(void);
-void DS_init(int GPIO);
+void ds18b20_send(char bit);
+unsigned char ds18b20_read(void);
+void ds18b20_send_byte(char data);
+unsigned char ds18b20_read_byte(void);
+unsigned char ds18b20_RST_PULSE(void);
+float ds18b20_get_temp(void);
+void ds18b20_init(int GPIO);
 
 #endif


### PR DESCRIPTION
Closes #1 

I just wasted several hours figuring out the issue:

"An invalid SSL record was received" from mbedtls_ssl_handshake()
 (MBEDTLS_ERR_SSL_INVALID_RECORD   -0x7200)

All due to a method name collision.